### PR TITLE
Fix error missing_parser in up/idle/down

### DIFF
--- a/drivers/Shutter-Panel/device.js
+++ b/drivers/Shutter-Panel/device.js
@@ -14,7 +14,7 @@ class ShutterPanel extends ZwaveDevice {
 		this.registerCapability('windowcoverings_state', 'BASIC', {
 			get: 'BASIC_GET',
 			set: 'BASIC_SET',
-			setParserV2: value => {
+			setParser: value => {
 
 				let invertDirection = false;
 				// if (node.hasOwnProperty('settings') && node.settings.hasOwnProperty('invert_direction')) {


### PR DESCRIPTION
Hi, 
Geen idee waarom er een setParserV2 staat maar zonder v2 werkt het zonder fouten.
Verder werkt dit zo ver ik nu zie goed much sieraden idle die meeste het rolluik een stukje terug ze aangezien  de MCO zich  meer als een dimmer gedraagt en het lijkt of er geen up/down of stop commando's gestuurd kunnen worden.
Ergens in een andere Driver staat ook nog een setParserV2 ! Geen idee of het daar wel werkt.